### PR TITLE
Add link to a popular SD cheat sheet

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -1,4 +1,4 @@
-import { BoldOutlined, GithubOutlined } from '@ant-design/icons';
+import { BoldOutlined, GithubOutlined, SnippetsFilled } from '@ant-design/icons';
 import { Button, Modal, Space } from 'antd';
 import { useResponsive } from 'antd-style';
 import qs from 'query-string';
@@ -90,6 +90,13 @@ const Header = memo<HeaderProps>(({ children }) => {
               target="_blank"
             >
               <Button icon={<BoldOutlined />} title="Birme" />
+            </a>
+            <a
+              href="https://supagruen.github.io/StableDiffusion-CheatSheet"
+              rel="noreferrer"
+              target="_blank"
+            >
+              <Button icon={<SnippetsFilled />} title="Cheat Sheet" />
             </a>
             <Button icon={<GithubOutlined />} onClick={showModal} title="Feedback" />
             <Setting />


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

Added a link to a [popular cheat sheet](https://supagruen.github.io/StableDiffusion-CheatSheet/) ([repo](https://github.com/SupaGruen/StableDiffusion-CheatSheet)).

#### 📝 补充信息 | Additional Information

I think the cheat sheet is a huge help to beginners but also people that want to experiment with different styles and image types.

The change looks like this:

<img width="254" alt="Screenshot 2023-06-11 at 5 12 09 PM" src="https://github.com/canisminor1990/sd-webui-kitchen-theme/assets/3636406/3ac1011a-dfa6-4529-b499-d86171e1ffe1">

<img width="243" alt="Screenshot 2023-06-11 at 5 12 21 PM" src="https://github.com/canisminor1990/sd-webui-kitchen-theme/assets/3636406/76a1499b-1c1d-4144-8c25-174549e095a3">

