### PR TITLE
fix tagger rating progress bar color

### DIFF
--- a/src/styles/tokens.ts
+++ b/src/styles/tokens.ts
@@ -165,7 +165,7 @@ export default (token: Theme) => {
       --prose-text-weight: 400;
       --prose-header-text-weight: 600;
       --slider-color: ${token.colorPrimary};
-      --stat-background-fill: l${token.colorInfoBg};
+      --stat-background-fill: ${token.geekblue4};
       --table-border-color: ${token.colorBorderSecondary};
       --table-even-background-fill: transparent;
       --table-odd-background-fill: ${token.colorFillTertiary};


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [x] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

In the tagger plugin panel, the original rating style is missing, as shown here
![图片](https://github.com/lobehub/sd-webui-lobe-theme/assets/9391981/ae52c68d-d83d-4d73-9b28-c65126e3c34f)

Even after removing the extra `l`, the contrast is so low that it is difficult to see the bars
![图片](https://github.com/lobehub/sd-webui-lobe-theme/assets/9391981/ae9a193b-7d2e-4900-b7e2-f533e5d9aad9)

So the color was changed to the color corresponding to primary-300, and after the fix

![图片](https://github.com/lobehub/sd-webui-lobe-theme/assets/9391981/e6523987-6da0-46fd-a05f-4c40f5afe9b8)
![图片](https://github.com/lobehub/sd-webui-lobe-theme/assets/9391981/12ce0315-83c3-4385-bc19-3e7a8ba29d62)


<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->
